### PR TITLE
Add missing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,7 @@ imutils==0.5.4
 opencv-contrib-python==4.10.0.84
 opencv-python==4.10.0.84
 PyMuPDF==1.25.1
+PyYAML==6.0.2
+scipy==1.14.1
 torch==2.5.1
 torchvision==0.20.1


### PR DESCRIPTION
When attempting to run `do_ocr.py`, I get

```
Traceback (most recent call last):
  File "/home/basil/src/neanes/byzantine-chant-ocr/scripts/do_ocr.py", line 19, in <module>
    from ocr import process_image, process_pdf
  File "/home/basil/src/neanes/byzantine-chant-ocr/scripts/../src/ocr.py", line 10, in <module>
    from segmentation import segment
  File "/home/basil/src/neanes/byzantine-chant-ocr/scripts/../src/segmentation.py", line 12, in <module>
    from scipy import signal, stats
ModuleNotFoundError: No module named 'scipy'
```

and

```
Traceback (most recent call last):
  File "/home/basil/src/neanes/byzantine-chant-ocr/scripts/do_ocr.py", line 15, in <module>
    import yaml
ModuleNotFoundError: No module named 'yaml'
```

Adding these missing dependencies fixes the issue.