### PR TITLE
Revert "Bump pyside6 from 6.8.1 to 6.8.1.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ opencv-python==4.10.0.84
 PyMuPDF==1.25.1
 PyYAML==6.0.2
 scipy==1.14.1
-PySide6==6.8.1.1
+PySide6==6.8.1


### PR DESCRIPTION
Reverts neanes/byzantine-chant-ocr#9 because I cannot seem to download 6.8.1.1 with `pip`.