### PR TITLE
chore: Use non-deprecated scipy.ndimage.rotate import

### DIFF
--- a/src/util.py
+++ b/src/util.py
@@ -3,7 +3,7 @@ import math
 import cv2
 import imutils
 import numpy as np
-from scipy.ndimage import interpolation as inter
+from scipy.ndimage import rotate
 
 
 def to_binary(image):
@@ -92,7 +92,7 @@ def pixels_in_row(binary_image):
 
 def find_skew_angles(binary_image, limit, delta):
     def determine_score(arr, angle):
-        data = inter.rotate(arr, angle, reshape=False, order=0)
+        data = rotate(arr, angle, reshape=False, order=0)
         histogram = np.sum(data, axis=1, dtype=float)
         score = np.sum((histogram[1:] - histogram[:-1]) ** 2, dtype=float)
         return score
@@ -135,7 +135,7 @@ def deskew(img, limit, delta):
     lower_limit = min(sorted_angles[:3])
 
     def determine_score(angle):
-        data = inter.rotate(binary_image, angle, reshape=False, order=0)
+        data = rotate(binary_image, angle, reshape=False, order=0)
         histogram = np.sum(data, axis=1, dtype=float)
         score = np.sum((histogram[1:] - histogram[:-1]) ** 2, dtype=float)
         return score


### PR DESCRIPTION
The `scipy.ndimage.interpolation` namespace is slated for removal in SciPy 2.0.0.

```
test_ocr_e2e.py: 66 warnings
byzantine-chant-ocr/e2e/../src/util.py:95: DeprecationWarning: Please import `rotate` from the `scipy.ndimage` namespace; the `scipy.ndimage.interpolation` namespace is deprecated and will be removed in SciPy 2.0.0.
    data = inter.rotate(arr, angle, reshape=False, order=0)

test_ocr_e2e.py: 84 warnings
  byzantine-chant-ocr/e2e/../src/util.py:138: DeprecationWarning: Please import `rotate` from the `scipy.ndimage` namespace; the `scipy.ndimage.interpolation` namespace is deprecated and will be removed in SciPy 2.0.0.
    data = inter.rotate(binary_image, angle, reshape=False, order=0)
```

Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html