### PR TITLE
chore: Migrate ONNX export to torch.export-based exporter

### DIFF
--- a/requirements-ci-model.txt
+++ b/requirements-ci-model.txt
@@ -1,3 +1,5 @@
 onnx==1.21.0
+onnxruntime==1.26.0
+onnxscript==0.7.0
 torch==2.11.0
 torchvision==0.26.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ fiftyone==1.15.0
 isort==8.0.1
 jupyter==1.1.1
 onnx==1.21.0
+onnxscript==0.7.0
 pytest==9.0.3
 torch==2.11.0
 torchvision==0.26.0

--- a/scripts/convert_to_onnx.py
+++ b/scripts/convert_to_onnx.py
@@ -15,25 +15,30 @@ from model_metadata import load_metadata
 
 
 def convert_to_onnx(model, onnx_path):
+    # Export on CPU: PyTorch CUDA matmul uses TF32 (10-bit mantissa) while ORT
+    # CPU uses full fp32, so verify=True would flag spurious ~1e-2 drift on a
+    # CUDA-loaded model. The exported .onnx is device-agnostic regardless.
+    model = model.cpu()
     model.eval()
 
-    device = next(model.parameters()).device
     size = 224
-    dummy_input = torch.randn(1, 3, size, size, device=device)
+    dummy_input = torch.randn(1, 3, size, size)
 
-    torch.onnx.export(
+    onnx_program = torch.onnx.export(
         model,
-        dummy_input,
-        onnx_path,
-        export_params=True,  # Store the trained parameters in the model file
-        opset_version=11,  # ONNX version to use (11 is commonly supported)
-        input_names=["input"],  # Name of input layer(s)
-        output_names=["output"],  # Name of output layer(s)
-        dynamic_axes={
-            "input": {0: "batch_size", 2: "height", 3: "width"},
-        },
-        dynamo=False,
+        (dummy_input,),
+        input_names=["input"],
+        output_names=["output"],
+        # Positional tuple, not a dict: dict keys for dynamic_shapes must match the
+        # forward() parameter name ("x" for MobileNetV2), not input_names.
+        dynamic_shapes=({0: "batch", 2: "height", 3: "width"},),
+        verify=True,
     )
+    # input_names/output_names are hints the dynamo exporter may override on conflicts;
+    # src/ocr.py hardcodes these strings, so guard the contract.
+    assert onnx_program.model.graph.inputs[0].name == "input"
+    assert onnx_program.model.graph.outputs[0].name == "output"
+    onnx_program.save(onnx_path, external_data=False)
 
 
 if __name__ == "__main__":

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -198,6 +198,11 @@ def train(model_version="0.0.0", num_epochs=50):
             for phase in ["train", "val"]:
                 if phase == "train":
                     model.train()
+                    # Backbone is frozen (requires_grad=False), but that doesn't stop
+                    # BN running_mean/running_var from updating in train() mode. Keep
+                    # features in eval mode so frozen gamma/beta stay matched to the
+                    # pretrained running stats they were calibrated for.
+                    model.features.eval()
                 else:
                     model.eval()
 


### PR DESCRIPTION
Fixes #135

The legacy TorchScript-based exporter was pinned via `dynamo=False` in commit 027a953 to silence deprecation warnings. Switch to the `torch.export` exporter (default since PyTorch 2.9) and drop the pin.

## ONNX export (`scripts/convert_to_onnx.py`)

- `dynamic_axes` - `dynamic_shapes` (positional tuple form, since dict keys must match the model `forward()` arg name, not `input_names`).
- `export(f=path)` - `ONNXProgram.save(path, external_data=False)` for the recommended two-step pattern; `external_data=False` keeps the ONNX as a single self-contained file matching the release artifact.
- `verify=True` enables the built-in numerical equivalence check via ONNX Runtime. This exposed a training bug (see below)
- Force CPU export so PyTorch CUDA TF32 matmul does not produce spurious drift vs ORT's full fp32. I noticed this when training with my NVIDIA GPU vs AMD CPU.
- Add `onnxscript` (required for the dynamo path) and `onnxruntime` (required for `verify=True`) to dependency lists.

## Training fix (`scripts/train.py`)

Keep frozen backbone in `eval()` mode during the training phase. `requires_grad=False` does not stop BN `running_mean`/`running_var` from updating in `train()` mode; those are buffers, not parameters. Letting them drift while `gamma`/`beta` stay pinned at pretrained values produces a normalization mismatch that amplifies activations through the network and was empirically responsible for numerical drift during ONNX export. This was causing `verify=True` to fail.

## Testing done

Levenshtein:

- Total distance across 6 pages: **40 - 38** (-2 errors, ~5%)
- Mean per-page: 0.9655 - 0.9669 (+0.0014)
- Per-page: 3 better, 1 worse (`liturgica_karamanis`: -1 error), 2 same
- All pages still pass the 0.9 threshold in both runs

Scorecard similarity (mean): 0.8972 - 0.9169 (+2 percentage points)

Per-class direction:

- **quality**: improves on 5/6 pages: The clearest win
- **vareia**: big jump on `liturgica` (0.33-1.0), otherwise stable
- **time, gorgon**: mostly neutral with mixed small swings
- **accidental**: still terrible on most pages, one small win
- **fthora**: high variance