### PR TITLE
feat: Fine-tune last MobileNetV2 block and fix EarlyStopper weight aliasing

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -9,6 +9,7 @@ Usage: python train.py
 """
 
 import argparse
+import copy
 import csv
 import datetime
 import json
@@ -38,7 +39,7 @@ class EarlyStopper:
         if validation_loss < self.min_validation_loss:
             self.min_validation_loss = validation_loss
             self.counter = 0
-            self.best_model_weights = model.state_dict()
+            self.best_model_weights = copy.deepcopy(model.state_dict())
         elif validation_loss > (self.min_validation_loss + self.min_delta):
             self.counter += 1
             if self.counter >= self.patience:
@@ -78,7 +79,7 @@ def train(model_version="0.0.0", num_epochs=50):
 
     device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
-    # Define augmentations for training data
+    # Define preprocessing transforms
     data_transforms = {
         "train": transforms.Compose(
             [
@@ -173,13 +174,36 @@ def train(model_version="0.0.0", num_epochs=50):
     for param in model.features.parameters():
         param.requires_grad = False
 
+    # Unfreeze the last InvertedResidual block (features[17]) and the final
+    # 1x1 conv (features[18]) so the head of the backbone can adapt to neume
+    # crops, which are far enough from ImageNet that frozen features alone
+    # leave accuracy on the table.
+    for block in (model.features[17], model.features[18]):
+        for param in block.parameters():
+            param.requires_grad = True
+
+    # Discriminative learning rates: standard rate for the new classifier head,
+    # 10x lower for the unfrozen backbone tail to avoid catastrophic forgetting
+    # of the pretrained features.
     optimizer = optim.Adam(
-        model.classifier.parameters(), lr=0.001
-    )  # Only update classifier layers
+        [
+            {"params": model.classifier.parameters(), "lr": 1e-3},
+            {
+                "params": [p for p in model.features.parameters() if p.requires_grad],
+                "lr": 1e-4,
+            },
+        ]
+    )
     criterion = nn.CrossEntropyLoss()
 
-    # Training loop (same as before)
-    # patience=5, min_delta=1e-4
+    # Frozen backbone modules must stay in eval() during the train phase so
+    # their BN running stats remain matched to the pretrained gamma/beta.
+    # Unfrozen blocks stay in train() mode so their BN stats adapt alongside
+    # the weights being fine-tuned.
+    frozen_blocks = [
+        b for b in model.features if not any(p.requires_grad for p in b.parameters())
+    ]
+
     early_stopper = EarlyStopper(patience=3, min_delta=1e-3)
 
     stop_early = False
@@ -198,11 +222,8 @@ def train(model_version="0.0.0", num_epochs=50):
             for phase in ["train", "val"]:
                 if phase == "train":
                     model.train()
-                    # Backbone is frozen (requires_grad=False), but that doesn't stop
-                    # BN running_mean/running_var from updating in train() mode. Keep
-                    # features in eval mode so frozen gamma/beta stay matched to the
-                    # pretrained running stats they were calibrated for.
-                    model.features.eval()
+                    for block in frozen_blocks:
+                        block.eval()
                 else:
                     model.eval()
 


### PR DESCRIPTION
Requires #144. Unfreezes the last MobileNetV2 `InvertedResidual block (`features[17]`) and the final 1x1 conv (`features[18]`) during training so the backbone tail can adapt to neume-crop statistics. Inverted binary line-art is far from ImageNet, and frozen features were leaving accuracy on the table. With every conv block frozen, only the classifier layer learns from the dataset, and the model is bottlenecked on whichever ImageNet features happen to transfer to inverted binary line-art. Fine-tuning the tail two modules with a low LR is the standard transfer-learning recipe for niche domains and is the largest available accuracy lever short of changing the architecture.

- Uses discriminative learning rates: classifier head at `1e-3`, unfrozen backbone tail at `1e-4` (10x lower) to avoid catastrophic forgetting.
- BN running stats: frozen blocks stay in `eval()` during the train phase to remain matched to the pretrained g/b; unfrozen blocks stay in `train()` so their BN stats adapt with the weights.

Bug fix noticed while testing: Deep-copy `best_model_weights` in `EarlyStopper`. Previously the snapshot aliased the live `model.state_dict()` and kept mutating after capture, so the "best" weights restored on early stop were really whatever the model held at the last update, not the validation-loss minimum. In other words, `state_dict()` returns a new dict each call but its tensor values are references to the model's parameters, so without `copy.deepcopy` the snapshot was always aliased to the live weights and `model.load_state_dict(self.best_model_weights)` was a no-op rather than restoring the validation-loss minimum.

## Testing done

E2E test (`cd e2e && pytest`, 6 reference pages):

| Metric | Before | After | D |
|---|---|---|---|
| Total Levenshtein distance | 40 | 33 | **-7 (~17.5%)** |
| Mean per-page Levenshtein | 0.9655 | 0.9708 | +0.0052 |
| Pages improved / unchanged / regressed | -- | 4 / 2 / 0 | -- |
| Mean scorecard similarity | 0.8972 | 0.9219 | +2.5 pp |

All 6 pages still pass the 0.9 Levenshtein threshold. Biggest single-page Levenshtein gain: `anastasimatarion_john` and `heirmologion_john` (distance -2 each); largest scorecard gain: `heirmologion_john` (+3.6 pp).

Per-page Levenshtein distance:

| Page | Before | After |
|---|---|---|
| anastasimatarion_john_p0011 | 11 | **9** |
| heirmologion_john_p0120 | 5 | **3** |
| liturgica_karamanis_1990_p0257 | 8 | 8 |
| heirmologion_pandektis_1955_p0160 | 9 | **7** |
| doxastarion_pringos_p0141 | 7 | **6** |
| vespers_sam_p0411 | 0 | 0 |

Per-class trends:
- **quality**: standout win -- improvements on 5/6 pages, ranging from +3.5 pp (heirmologion_john) up to +22 pp (doxastarion_pringos: 0.778 - 1.0), with anastasimatarion_john at +16 pp and heirmologion_pandektis hitting a perfect 1.0
- **vareia**: huge unlock on `liturgica_karamanis` (0.333 - **1.0**, +66.7 pp), small +7.7 pp on doxastarion_pringos; 4 pages already at 1.0
- **accidental**: trending up from low bases (+0.5 on heirmologion_john, +0.2 on doxastarion_pringos, +0.05 on heirmologion_pandektis)
- **gorgon**: mostly stable -- +4.4 pp on heirmologion_john and +4.8 pp on liturgica_karamanis, one -5.9 pp regression on doxastarion_pringos
- **time**: mixed small swings, no large moves
- **fthora**: high variance -- wins on `anastasimatarion_john` (+0.5), `heirmologion_john` (+0.233), `doxastarion_pringos` (+0.444); regressions on `liturgica_karamanis` (-0.143), `heirmologion_pandektis` (-0.048), and `vespers_sam` (-0.5, hallucinated `diesisGenikiAbove` -- page Levenshtein still 1.0 because fthora additions don't break base-element alignment)

Verified empirically against `torchvision.models.mobilenet_v2`: `features` has 19 entries, `features[17]` is the last `InvertedResidual`, and `features[18]` is the final `Conv2dNormActivation` (1x1 conv to `last_channel=1280`): the right tail to unfreeze, and both contain BN layers. The two Adam param groups construct cleanly with no duplicate-param error: classifier and features are disjoint submodules, and `[p for p in model.features.parameters() if p.requires_grad]` returns exactly the 12 trainable tensors in blocks 17 and 18 while the classifier group holds the 2 new `Linear` params (Dropout has none). The generalized eval-mode loop correctly drives `features[0..16].training=False` and leaves `features[17]`, `features[18]`, and the classifier in `train()`, so frozen BN layers continue to use stored running stats matched to their frozen gamma/beta (preserving the prior ONNX-drift fix from #144), while the unfrozen tail's BN stats adapt alongside the weights being fine-tuned.